### PR TITLE
Some bugfixes, and minor feature updates

### DIFF
--- a/CPMPlayer.cs
+++ b/CPMPlayer.cs
@@ -60,7 +60,6 @@ public class CPMPlayer : MonoBehaviour
     public float sideStrafeAcceleration = 50.0f;  // How fast acceleration occurs to get up to sideStrafeSpeed when
     public float sideStrafeSpeed = 1.0f;          // What the max speed to generate when side strafing
     public float jumpSpeed = 8.0f;                // The speed at which the character's up axis gains when hitting jump
-    public float moveScale = 1.0f;
 
     /*print() style */
     public GUIStyle style;
@@ -196,7 +195,6 @@ public class CPMPlayer : MonoBehaviour
         float accel;
         
         SetMovementDir();
-        float scale = CmdScale();
 
         wishdir =  new Vector3(_cmd.rightMove, 0, _cmd.forwardMove);
         wishdir = transform.TransformDirection(wishdir);
@@ -206,7 +204,6 @@ public class CPMPlayer : MonoBehaviour
 
         wishdir.Normalize();
         moveDirectionNorm = wishdir;
-        wishspeed *= scale;
 
         // CPM: Aircontrol
         float wishspeed2 = wishspeed;
@@ -286,7 +283,6 @@ public class CPMPlayer : MonoBehaviour
             ApplyFriction(0);
 
         SetMovementDir();
-        float scale = CmdScale();
 
         wishdir = new Vector3(_cmd.rightMove, 0, _cmd.forwardMove);
         wishdir = transform.TransformDirection(wishdir);
@@ -366,32 +362,5 @@ public class CPMPlayer : MonoBehaviour
         ups.y = 0;
         GUI.Label(new Rect(0, 15, 400, 100), "Speed: " + Mathf.Round(ups.magnitude * 100) / 100 + "ups", style);
         GUI.Label(new Rect(0, 30, 400, 100), "Top Speed: " + Mathf.Round(playerTopVelocity * 100) / 100 + "ups", style);
-    }
-
-    /*
-    ============
-    PM_CmdScale
-
-    Returns the scale factor to apply to cmd movements
-    This allows the clients to use axial -127 to 127 values for all directions
-    without getting a sqrt(2) distortion in speed.
-    ============
-    */
-    private float CmdScale()
-    {
-        int max;
-        float total;
-        float scale;
-
-        max = (int)Mathf.Abs(_cmd.forwardMove);
-        if(Mathf.Abs(_cmd.rightMove) > max)
-            max = (int)Mathf.Abs(_cmd.rightMove);
-        if(max <= 0)
-            return 0;
-
-        total = Mathf.Sqrt(_cmd.forwardMove * _cmd.forwardMove + _cmd.rightMove * _cmd.rightMove);
-        scale = moveSpeed * max / (moveScale * total);
-
-        return scale;
     }
 }

--- a/CPMPlayer.cs
+++ b/CPMPlayer.cs
@@ -60,6 +60,7 @@ public class CPMPlayer : MonoBehaviour
     public float sideStrafeAcceleration = 50.0f;  // How fast acceleration occurs to get up to sideStrafeSpeed when
     public float sideStrafeSpeed = 1.0f;          // What the max speed to generate when side strafing
     public float jumpSpeed = 8.0f;                // The speed at which the character's up axis gains when hitting jump
+    public bool holdJumpToBhop = false;           // When enabled allows player to just hold jump button to keep on bhopping perfectly. Beware: smells like casual.
 
     /*print() style */
     public GUIStyle style;
@@ -179,6 +180,12 @@ public class CPMPlayer : MonoBehaviour
      */
     private void QueueJump()
     {
+        if(holdJumpToBhop)
+        {
+            wishJump = Input.GetButton("Jump");
+            return;
+        }
+
         if(Input.GetButtonDown("Jump") && !wishJump)
             wishJump = true;
         if(Input.GetButtonUp("Jump"))

--- a/CPMPlayer.cs
+++ b/CPMPlayer.cs
@@ -97,6 +97,13 @@ public class CPMPlayer : MonoBehaviour
         Cursor.visible = false;
         Cursor.lockState = CursorLockMode.Locked;
 
+        if (playerView == null)
+        {
+            Camera mainCamera = Camera.main;
+            if (mainCamera != null)
+                playerView = mainCamera.gameObject.transform;
+        }
+
         // Put the camera inside the capsule collider
         playerView.position = new Vector3(
             transform.position.x,

--- a/CPMPlayer.cs
+++ b/CPMPlayer.cs
@@ -38,7 +38,7 @@ struct Cmd
     public float upMove;
 }
 
-public class GMSPlayer : MonoBehaviour
+public class CPMPlayer : MonoBehaviour
 {
     public Transform playerView;     // Camera
     public float playerViewYOffset = 0.6f; // The height at which the camera is bound to

--- a/CPMPlayer.cs
+++ b/CPMPlayer.cs
@@ -150,8 +150,8 @@ public class CPMPlayer : MonoBehaviour
         /* Calculate top velocity */
         Vector3 udp = playerVelocity;
         udp.y = 0.0f;
-        if(playerVelocity.magnitude > playerTopVelocity)
-            playerTopVelocity = playerVelocity.magnitude;
+        if(udp.magnitude > playerTopVelocity)
+            playerTopVelocity = udp.magnitude;
 
         //Need to move the camera after the player has been moved because otherwise the camera will clip the player if going fast enough and will always be 1 frame behind.
         // Set the camera's position to the transform

--- a/CPMPlayer.js
+++ b/CPMPlayer.js
@@ -35,6 +35,7 @@ var airControl             : float = 0.3;  // How precise air control is
 var sideStrafeAcceleration : float = 50;   // How fast acceleration occurs to get up to sideStrafeSpeed when side strafing
 var sideStrafeSpeed        : float = 1;    // What the max speed to generate when side strafing
 var jumpSpeed              : float = 8.0;  // The speed at which the character's up axis gains when hitting jump
+var holdJumpToBhop         : boolean = false; // When enabled allows player to just hold jump button to keep on bhopping perfectly. Beware: smells like casual.
 
 /* print() styles */
 var style : GUIStyle;
@@ -179,6 +180,11 @@ function SetMovementDir()
  */
 function QueueJump()
 {
+    if(holdJumpToBhop) {
+        wishJump = Input.GetKey(KeyCode.Space);
+        return;
+    }
+
 	if(Input.GetKeyDown(KeyCode.Space) && !wishJump)
 		wishJump = true;
 	if(Input.GetKeyUp(KeyCode.Space))

--- a/CPMPlayer.js
+++ b/CPMPlayer.js
@@ -35,7 +35,6 @@ var airControl             : float = 0.3;  // How precise air control is
 var sideStrafeAcceleration : float = 50;   // How fast acceleration occurs to get up to sideStrafeSpeed when side strafing
 var sideStrafeSpeed        : float = 1;    // What the max speed to generate when side strafing
 var jumpSpeed              : float = 8.0;  // The speed at which the character's up axis gains when hitting jump
-var moveScale              : float = 1.0;
 
 /* print() styles */
 var style : GUIStyle;
@@ -195,8 +194,6 @@ function AirMove()
 	var wishvel : float = airAcceleration;
 	var accel : float;
 
-	var scale = CmdScale();
-
 	SetMovementDir();
 	
 	wishdir = Vector3(cmd.rightmove, 0, cmd.forwardmove);
@@ -207,7 +204,6 @@ function AirMove()
 	
 	wishdir.Normalize();
 	moveDirectionNorm = wishdir;
-	wishspeed *= scale;
 
 	// CPM: Aircontrol
 	var wishspeed2 = wishspeed;
@@ -291,8 +287,6 @@ function GroundMove()
 		ApplyFriction(1.0);
 	else
 		ApplyFriction(0);
-
-	var scale = CmdScale();
 
 	SetMovementDir();
 
@@ -389,32 +383,6 @@ function OnGUI()
 	GUI.Label(Rect(0, 30, 400, 100), "Top Speed: " + Mathf.Round(playerTopVelocity * 100) / 100 + "ups", style);
 }
 
-/*
-============
-PM_CmdScale
-
-Returns the scale factor to apply to cmd movements
-This allows the clients to use axial -127 to 127 values for all directions
-without getting a sqrt(2) distortion in speed.
-============
-*/
-function CmdScale()
-{
-	var max : int;
-	var total : float;
-	var scale : float;
-
-	max = Mathf.Abs(cmd.forwardmove);
-	if(Mathf.Abs(cmd.rightmove) > max)
-		max = Mathf.Abs(cmd.rightmove);
-	if(!max)
-		return 0;
-
-	total = Mathf.Sqrt(cmd.forwardmove * cmd.forwardmove + cmd.rightmove * cmd.rightmove);
-	scale = moveSpeed * max / (moveScale * total);
-
-	return scale;
-}
 
 function PlayerExplode()
 {

--- a/CPMPlayer.js
+++ b/CPMPlayer.js
@@ -152,8 +152,8 @@ function Update()
 	/* Calculate top velocity */
 	var udp = playerVelocity;
 	udp.y = 0.0;
-	if(playerVelocity.magnitude > playerTopVelocity)
-		playerTopVelocity = playerVelocity.magnitude;
+	if(udp.magnitude > playerTopVelocity)
+		playerTopVelocity = udp.magnitude;
 
 	if(Input.GetKeyUp('x'))
 		PlayerExplode();

--- a/CPMPlayer.js
+++ b/CPMPlayer.js
@@ -87,8 +87,8 @@ private var playerSpawnRot : Quaternion;
 function Start()
 {
 	/* Hide the cursor */
-	Screen.showCursor = false;
-	Screen.lockCursor = true;
+	Cursor.visible = false;
+    Cursor.lockState = CursorLockMode.Locked;
 
 	/* Put the camera inside the capsule collider */
 	playerView.position = this.transform.position;
@@ -115,10 +115,10 @@ function Update()
 	}
 
 	/* Ensure that the cursor is locked into the screen */
-	if(Screen.lockCursor == false)
+	if(Cursor.lockState != CursorLockMode.Locked)
 	{
 		if(Input.GetMouseButtonDown(0))
-			Screen.lockCursor = true;
+            Cursor.lockState = CursorLockMode.Locked;
 	}
 
 	/* Camera rotation stuff, mouse controls this shit */


### PR DESCRIPTION
Hello!
Thank you for saving me the time of prototyping quake movement in unity. Here is my little payback.

I updated the JS script to drop use of obsolete APIs (made compatible with Unity 2018).

Also in both C# and JS scripts:

- I fixed the overaccel over Z axis (forwards/backwards) in midair. Although I'd appreciate testing if that bug ever occured for anyone else but me. To reproduce simply jump and hold forwards and watch yourself fly breeze through the air at ~40 ups (while MaxSpeed is just 7 and we're not even strafin).
- Top Velocity stat display used to display wrong value because it was also adding the Y axis (up/down) into calculations, which is not what we interested in most likely.
- Implemented holdToJump option toggle, just a quality of life for some filthy casuals like me, who get bored to time the jumps even with queueing 😄 

Csharp script tries to use Camera.main as playerView if the latter is null when script Start.

I appreciate any edits/feedback and etc.

Thanks!